### PR TITLE
Add test file whitelist

### DIFF
--- a/index_with_finish_button.html
+++ b/index_with_finish_button.html
@@ -37,12 +37,15 @@
             <p id="final-score"></p>
         </div>
         <button class="button" id="restart-button" style="display:none;">Начать заново</button>
+        <button class="button" id="switch-test-button">Сменить тест</button>
     </div>
 
     <script>
         let QUESTIONS = [];
         let currentQuestionIndex = 0;
         let score = 0;
+        const TEST_FILES = ["PM04.json", "PM03.json"];
+        let currentTestFileIndex = 0;
 
         // Функция для перемешивания массива
         function shuffle(array) {
@@ -54,7 +57,8 @@
 
         // Загрузка вопросов с сервера
         async function loadQuestions() {
-            const response = await fetch("/questions");
+            const file = TEST_FILES[currentTestFileIndex];
+            const response = await fetch(`/questions?file=${encodeURIComponent(file)}`);
             QUESTIONS = await response.json();
             QUESTIONS.forEach(q => shuffle(q.options)); // Перемешиваем варианты перед началом
             showQuestion();
@@ -135,15 +139,20 @@
         // Обработчик кнопки "Начать заново"
         document.getElementById("restart-button").addEventListener("click", restartTest);
 
+        // Обработчик кнопки "Сменить тест"
+        document.getElementById("switch-test-button").addEventListener("click", async () => {
+            currentTestFileIndex = (currentTestFileIndex + 1) % TEST_FILES.length;
+            await restartTest();
+        });
+
         // Сброс теста и начало заново
-        function restartTest() {
+        async function restartTest() {
             currentQuestionIndex = 0;
             score = 0;
-            QUESTIONS.forEach(q => shuffle(q.options)); // Перемешиваем варианты
             document.getElementById("result-section").style.display = "none";
             document.getElementById("question-section").style.display = "block";
             document.getElementById("restart-button").style.display = "none";
-            showQuestion();
+            await loadQuestions();
         }
 
         loadQuestions();

--- a/main.py
+++ b/main.py
@@ -1,18 +1,32 @@
 import json
 from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
 
-# Загружаем вопросы из JSON-файла
-with open("PM04.json", "r", encoding="utf-8") as f:
-    QUESTIONS = json.load(f)
+ALLOWED_FILES = {"PM03.json", "PM04.json"}
 
 # Обработчик HTTP-запросов
 class MyHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
-        if self.path == "/questions":
-            self.send_response(200)
-            self.send_header("Content-type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(QUESTIONS).encode("utf-8"))
+        if self.path.startswith("/questions"):
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            filename = params.get("file", ["PM04.json"])[0]
+
+            if filename not in ALLOWED_FILES:
+                self.send_response(400)
+                self.end_headers()
+                return
+
+            try:
+                with open(filename, "r", encoding="utf-8") as f:
+                    questions = json.load(f)
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(questions).encode("utf-8"))
+            except FileNotFoundError:
+                self.send_response(404)
+                self.end_headers()
         else:
             super().do_GET()
 


### PR DESCRIPTION
## Summary
- restrict which JSON files can be served
- keep ability to switch tests via the UI

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6849b60175348327a4e2be362b41d4bb